### PR TITLE
bugfix/accurics_remediation_7581033908249917 - Auto Generated Pull Request From Accurics

### DIFF
--- a/terraform/aws/modules/storage/main.tf
+++ b/terraform/aws/modules/storage/main.tf
@@ -47,7 +47,7 @@ resource "aws_db_instance" "km_db" {
   allocated_storage         = 20
   engine                    = "postgres"
   engine_version            = "10.6"
-  instance_class            = "db.t3.medium"
+  instance_class            = "db.m5.xlarge"
   storage_type              = "gp2"
   password                  = var.db_password
   username                  = var.db_username


### PR DESCRIPTION
Configure the AWS instances to follow certain AWS Best Practice recommendations. Some of these are: 
 1. Enable performance insights. 
 2. Ensure allocated storage is not less than 200. 
 3. Ensure max allocated storage is not less than 500. 
 4. Consider using 'db.m5.xlarge' instance class for all instances.